### PR TITLE
Fix upsample module lacking recompute_scale_factor attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python3 -m pip install --upgrade pip
 `detect.py` (from original [YOLOv5 repo](https://github.com/ultralytics/yolov5)) runs inference on a variety of sources (images, videos, video streams, webcam, etc.) and saves results to `runs/detect`  
 For example, to detect people in an image using the pre-trained YOLOv5s model with a 40% confidence threshold, we simply have to run the following command in a terminal in the source directory:
 ```
-python detect.py --class 0 --weights Yolov5s.pt --conf-thres=0.4 --source example_pic.jpeg --view-img 
+python detect.py --class 0 --weights yolov5s.pt --conf-thres=0.4 --source example_pic.jpeg --view-img 
 ```
 
 This will automatically save the results in the directory `runs/detect/exp` as an annotated image with a label and the confidence levels of the prediction. 
@@ -32,5 +32,5 @@ python detect_pcap.py --class 0 --weights best.pt --conf-thres=0.4 --source Oust
 ```
 To calculate the relative distance between two people:
 ```
-python detect_PCAP.py --class 0 --weights best.pt --conf-thres=0.4 --source Ouster-YOLOv5-sample.pcap --metadata-path Ouster-YOLOv5-sample.json  --view-img --social-distance
+python detect_pcap.py --class 0 --weights best.pt --conf-thres=0.4 --source Ouster-YOLOv5-sample.pcap --metadata-path Ouster-YOLOv5-sample.json  --view-img --social-distance
 ```

--- a/detect.py
+++ b/detect.py
@@ -170,7 +170,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
             im0 = annotator.result()
             if view_img:
                 cv2.imshow(str(p), im0)
-                cv2.waitKey(1)  # 1 millisecond
+                cv2.waitKey(1000)  # 1 second
 
             # Save results (image with detections)
             if save_img:


### PR DESCRIPTION
## Related PR(s)
- None

## Summary of Changes
- Set recompute_scale_factor attribute to **Upsample** module when not found
- Fix typos in the README

## Validation
* Clone this repository
  ```bash
  git clone https://github.com/ouster-lidar/yolov5-ouster-lidar-example
  ```
* Update to the PR branch
  ```bash
  git checkout fix-upsample-lacking-recompute-scale-factor-attribute
  ```
* Install requirements
  ```bash
  pip install -r requirements.txt
  pip install ouster-sdk
  ```
* Run the command:
  ```bash
  python3 detect.py --class 0 --weights Yolov5s.pt --conf-thres=0.4 --source example_pic.jpeg --view-img 
  ```